### PR TITLE
Add authentication and role-based access control MVP

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -5,7 +5,9 @@ A super simple FastAPI application that allows students to view and sign up for 
 ## Features
 
 - View all available extracurricular activities
-- Sign up for activities
+- Register and log in users
+- Role-based access control (`admin`, `activity-manager`, `student`)
+- Only `admin` and `activity-manager` can register/unregister students in activities
 
 ## Getting Started
 
@@ -29,8 +31,19 @@ A super simple FastAPI application that allows students to view and sign up for 
 
 | Method | Endpoint                                                          | Description                                                         |
 | ------ | ----------------------------------------------------------------- | ------------------------------------------------------------------- |
-| GET    | `/activities`                                                     | Get all activities with their details and current participant count |
-| POST   | `/activities/{activity_name}/signup?email=student@mergington.edu` | Sign up for an activity                                             |
+| POST   | `/auth/register`                                                  | Register a user (default role: `student`)                           |
+| POST   | `/auth/login`                                                     | Log in and receive bearer token                                     |
+| POST   | `/auth/logout`                                                    | Invalidate current session token                                    |
+| GET    | `/auth/me`                                                        | Get current authenticated user                                      |
+| GET    | `/activities`                                                     | Get all activities (requires login)                                 |
+| POST   | `/activities/{activity_name}/signup?email=student@mergington.edu` | Register a student in an activity (admin/manager only)             |
+| DELETE | `/activities/{activity_name}/unregister?email=student@...`        | Unregister a student (admin/manager only)                           |
+
+## Default Test Accounts
+
+- `admin@mergington.edu` / `admin123`
+- `manager@mergington.edu` / `manager123`
+- `student@mergington.edu` / `student123`
 
 ## Data Model
 

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -3,15 +3,107 @@ document.addEventListener("DOMContentLoaded", () => {
   const activitySelect = document.getElementById("activity");
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
+  const loginForm = document.getElementById("login-form");
+  const registerForm = document.getElementById("register-form");
+  const logoutBtn = document.getElementById("logout-btn");
+  const authStatus = document.getElementById("auth-status");
+  const signupPermissionHint = document.getElementById("signup-permission-hint");
+
+  let currentUser = null;
+
+  function getToken() {
+    return localStorage.getItem("authToken");
+  }
+
+  function setToken(token) {
+    localStorage.setItem("authToken", token);
+  }
+
+  function clearToken() {
+    localStorage.removeItem("authToken");
+  }
+
+  function authHeaders() {
+    const token = getToken();
+    if (!token) {
+      return {};
+    }
+    return { Authorization: `Bearer ${token}` };
+  }
+
+  function showMessage(text, type = "info") {
+    messageDiv.textContent = text;
+    messageDiv.className = type;
+    messageDiv.classList.remove("hidden");
+
+    setTimeout(() => {
+      messageDiv.classList.add("hidden");
+    }, 5000);
+  }
+
+  function canManageEnrollments() {
+    return (
+      currentUser &&
+      (currentUser.role === "admin" || currentUser.role === "activity-manager")
+    );
+  }
+
+  function updateAuthUI() {
+    if (!currentUser) {
+      authStatus.textContent = "Not logged in";
+      loginForm.classList.remove("hidden");
+      registerForm.classList.remove("hidden");
+      logoutBtn.classList.add("hidden");
+      signupForm.classList.add("hidden");
+      signupPermissionHint.textContent = "Login as admin or activity-manager to register/unregister students.";
+      return;
+    }
+
+    authStatus.textContent = `Logged in as ${currentUser.email} (${currentUser.role})`;
+    loginForm.classList.add("hidden");
+    registerForm.classList.add("hidden");
+    logoutBtn.classList.remove("hidden");
+
+    if (canManageEnrollments()) {
+      signupForm.classList.remove("hidden");
+      signupPermissionHint.textContent = "You can manage enrollment for all activities.";
+    } else {
+      signupForm.classList.add("hidden");
+      signupPermissionHint.textContent = "Student accounts can only view activity lists and participants.";
+    }
+  }
+
+  function renderLoginRequired() {
+    activitiesList.innerHTML = "<p>Please log in to view activities.</p>";
+    activitySelect.innerHTML = "<option value=''>-- Login required --</option>";
+  }
 
   // Function to fetch activities from API
   async function fetchActivities() {
+    if (!getToken()) {
+      renderLoginRequired();
+      return;
+    }
+
     try {
-      const response = await fetch("/activities");
+      const response = await fetch("/activities", {
+        headers: authHeaders(),
+      });
+
+      if (response.status === 401) {
+        currentUser = null;
+        clearToken();
+        updateAuthUI();
+        renderLoginRequired();
+        showMessage("Session expired. Please log in again.", "error");
+        return;
+      }
+
       const activities = await response.json();
 
       // Clear loading message
       activitiesList.innerHTML = "";
+      activitySelect.innerHTML = "<option value=''>-- Select an activity --</option>";
 
       // Populate activities list
       Object.entries(activities).forEach(([name, details]) => {
@@ -30,7 +122,11 @@ document.addEventListener("DOMContentLoaded", () => {
                 ${details.participants
                   .map(
                     (email) =>
-                      `<li><span class="participant-email">${email}</span><button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button></li>`
+                      `<li><span class="participant-email">${email}</span>${
+                        canManageEnrollments()
+                          ? `<button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button>`
+                          : ""
+                      }</li>`
                   )
                   .join("")}
               </ul>
@@ -69,6 +165,11 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // Handle unregister functionality
   async function handleUnregister(event) {
+    if (!canManageEnrollments()) {
+      showMessage("You do not have permission to unregister students.", "error");
+      return;
+    }
+
     const button = event.target;
     const activity = button.getAttribute("data-activity");
     const email = button.getAttribute("data-email");
@@ -80,32 +181,22 @@ document.addEventListener("DOMContentLoaded", () => {
         )}/unregister?email=${encodeURIComponent(email)}`,
         {
           method: "DELETE",
+          headers: authHeaders(),
         }
       );
 
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        showMessage(result.message, "success");
 
         // Refresh activities list to show updated participants
         fetchActivities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        showMessage(result.detail || "An error occurred", "error");
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to unregister. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      showMessage("Failed to unregister. Please try again.", "error");
       console.error("Error unregistering:", error);
     }
   }
@@ -113,6 +204,11 @@ document.addEventListener("DOMContentLoaded", () => {
   // Handle form submission
   signupForm.addEventListener("submit", async (event) => {
     event.preventDefault();
+
+    if (!canManageEnrollments()) {
+      showMessage("You do not have permission to register students.", "error");
+      return;
+    }
 
     const email = document.getElementById("email").value;
     const activity = document.getElementById("activity").value;
@@ -124,37 +220,136 @@ document.addEventListener("DOMContentLoaded", () => {
         )}/signup?email=${encodeURIComponent(email)}`,
         {
           method: "POST",
+          headers: authHeaders(),
         }
       );
 
       const result = await response.json();
 
       if (response.ok) {
-        messageDiv.textContent = result.message;
-        messageDiv.className = "success";
+        showMessage(result.message, "success");
         signupForm.reset();
 
         // Refresh activities list to show updated participants
         fetchActivities();
       } else {
-        messageDiv.textContent = result.detail || "An error occurred";
-        messageDiv.className = "error";
+        showMessage(result.detail || "An error occurred", "error");
       }
-
-      messageDiv.classList.remove("hidden");
-
-      // Hide message after 5 seconds
-      setTimeout(() => {
-        messageDiv.classList.add("hidden");
-      }, 5000);
     } catch (error) {
-      messageDiv.textContent = "Failed to sign up. Please try again.";
-      messageDiv.className = "error";
-      messageDiv.classList.remove("hidden");
+      showMessage("Failed to sign up. Please try again.", "error");
       console.error("Error signing up:", error);
     }
   });
 
+  loginForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+
+    const email = document.getElementById("login-email").value;
+    const password = document.getElementById("login-password").value;
+
+    try {
+      const response = await fetch("/auth/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, password }),
+      });
+
+      const result = await response.json();
+
+      if (!response.ok) {
+        showMessage(result.detail || "Login failed", "error");
+        return;
+      }
+
+      setToken(result.token);
+      currentUser = { email: result.email, role: result.role };
+      updateAuthUI();
+      fetchActivities();
+      showMessage("Login successful", "success");
+      loginForm.reset();
+    } catch (error) {
+      showMessage("Failed to log in. Please try again.", "error");
+      console.error("Error logging in:", error);
+    }
+  });
+
+  registerForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+
+    const email = document.getElementById("register-email").value;
+    const password = document.getElementById("register-password").value;
+
+    try {
+      const response = await fetch("/auth/register", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, password, role: "student" }),
+      });
+
+      const result = await response.json();
+
+      if (!response.ok) {
+        showMessage(result.detail || "Registration failed", "error");
+        return;
+      }
+
+      showMessage("Registration successful. You can now log in.", "success");
+      registerForm.reset();
+    } catch (error) {
+      showMessage("Failed to register. Please try again.", "error");
+      console.error("Error registering:", error);
+    }
+  });
+
+  logoutBtn.addEventListener("click", async () => {
+    try {
+      await fetch("/auth/logout", {
+        method: "POST",
+        headers: authHeaders(),
+      });
+    } catch (error) {
+      console.error("Error logging out:", error);
+    }
+
+    clearToken();
+    currentUser = null;
+    updateAuthUI();
+    renderLoginRequired();
+    showMessage("Logged out", "success");
+  });
+
+  async function restoreSession() {
+    if (!getToken()) {
+      updateAuthUI();
+      renderLoginRequired();
+      return;
+    }
+
+    try {
+      const response = await fetch("/auth/me", {
+        headers: authHeaders(),
+      });
+
+      if (!response.ok) {
+        clearToken();
+        currentUser = null;
+        updateAuthUI();
+        renderLoginRequired();
+        return;
+      }
+
+      currentUser = await response.json();
+      updateAuthUI();
+      fetchActivities();
+    } catch (error) {
+      clearToken();
+      currentUser = null;
+      updateAuthUI();
+      renderLoginRequired();
+      console.error("Error restoring session:", error);
+    }
+  }
+
   // Initialize app
-  fetchActivities();
+  restoreSession();
 });

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -10,9 +10,40 @@
     <header>
       <h1>Mergington High School</h1>
       <h2>Extracurricular Activities</h2>
+      <p id="auth-status" class="auth-status">Not logged in</p>
     </header>
 
     <main>
+      <section id="auth-container">
+        <h3>Login</h3>
+        <form id="login-form">
+          <div class="form-group">
+            <label for="login-email">Email:</label>
+            <input type="email" id="login-email" required placeholder="your-email@mergington.edu" />
+          </div>
+          <div class="form-group">
+            <label for="login-password">Password:</label>
+            <input type="password" id="login-password" required placeholder="Enter password" />
+          </div>
+          <button type="submit">Login</button>
+        </form>
+
+        <h3>Create Student Account</h3>
+        <form id="register-form">
+          <div class="form-group">
+            <label for="register-email">Email:</label>
+            <input type="email" id="register-email" required placeholder="student@mergington.edu" />
+          </div>
+          <div class="form-group">
+            <label for="register-password">Password:</label>
+            <input type="password" id="register-password" minlength="6" required placeholder="At least 6 characters" />
+          </div>
+          <button type="submit">Register</button>
+        </form>
+
+        <button id="logout-btn" class="hidden" type="button">Logout</button>
+      </section>
+
       <section id="activities-container">
         <h3>Available Activities</h3>
         <div id="activities-list">
@@ -22,7 +53,8 @@
       </section>
 
       <section id="signup-container">
-        <h3>Sign Up for an Activity</h3>
+        <h3>Manage Activity Enrollment</h3>
+        <p id="signup-permission-hint" class="info">Login as admin or activity-manager to register/unregister students.</p>
         <form id="signup-form">
           <div class="form-group">
             <label for="email">Student Email:</label>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -28,6 +28,11 @@ header h1 {
   margin-bottom: 10px;
 }
 
+.auth-status {
+  margin-top: 8px;
+  font-size: 14px;
+}
+
 main {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary
Implements a minimal authentication and role-based authorization flow for the school activities app.

### Backend
- Added auth endpoints: `POST /auth/register`, `POST /auth/login`, `POST /auth/logout`, `GET /auth/me`
- Added in-memory users and bearer-token sessions
- Added roles: `admin`, `activity-manager`, `student`
- Protected `GET /activities` behind authentication
- Restricted `POST /activities/{activity_name}/signup` and `DELETE /activities/{activity_name}/unregister` to admin/manager roles

### Frontend
- Added login, student self-registration, and logout UI
- Persisted session token in `localStorage`
- Added role-aware UI behavior:
  - `admin`/`activity-manager`: can manage enrollment
  - `student`: read-only view of activities/participants
- Added session restore and expired-session handling

### Docs
- Updated `src/README.md` with new endpoints, RBAC behavior, and default test accounts

## Validation
Manual smoke tests against local API:
- Unauthenticated `GET /activities` returns `401`
- Student login can read activities (`200`) but cannot signup (`403`)
- Activity manager login can signup students (`200`)